### PR TITLE
FIX: user verifier tests now pass

### DIFF
--- a/Website/Test/UserVerifierTests.cs
+++ b/Website/Test/UserVerifierTests.cs
@@ -26,7 +26,7 @@ namespace Test
             moq.Setup(es => es.LogOut());
             moq.Setup(es => es.LogIn());
             moq.Setup(es => es.SendTextEmail(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
-                .Returns(() => { return ""; });
+                .Returns(async () => { return ""; });
 
             return moq.Object;
         }


### PR DESCRIPTION
It was a breaking change in email service that didn't get patched. In other words, there was a bug in the test.